### PR TITLE
Require alt text

### DIFF
--- a/best_of_mltshp.py
+++ b/best_of_mltshp.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
                 continue
             toot = post_toot(encoded, attachment)
             if "id" in toot:
-                print(f"https://{MASTODON_INSTANCE}/{MASTODON_USER}/{toot["id"]}")
+                print(f"https://{MASTODON_INSTANCE}/{MASTODON_USER}/{toot['id']}")
             else:
                 raise Exception("Something went wrong")
             break

--- a/best_of_mltshp.py
+++ b/best_of_mltshp.py
@@ -65,8 +65,8 @@ def encode_toot(entry, alt_text):
     toot = entry.link
     if entry.title != "":
         toot += f" “{entry.title}”"
-    if alt_text == "":
-        toot += "\n#alt4me"
+    if alt_text == "" or alt_text == "CDN Media" or alt_text == "image":
+        return False
     return toot
     
 
@@ -163,10 +163,12 @@ if __name__ == "__main__":
             os.remove(filename)
 
             # Post the toot
-            toot = post_toot(encode_toot(entry, alt_text), attachment)
-            if toot and "id" in toot:
-                toot_id = toot["id"]
-                print(f"https://{MASTODON_INSTANCE}/{MASTODON_USER}/{toot_id}")
+            encoded = encode_toot(entry, alt_text)
+            if encoded == False:
+                continue
+            toot = post_toot(encoded, attachment)
+            if "id" in toot:
+                print(f"https://{MASTODON_INSTANCE}/{MASTODON_USER}/{toot["id"]}")
             else:
                 raise Exception("Something went wrong")
             break

--- a/links.log
+++ b/links.log
@@ -1,3 +1,4 @@
+https://mltshp.com/p/1R8OY
 https://mltshp.com/p/1R8Q7
 https://mltshp.com/p/1R8P8
 https://mltshp.com/p/1R8QB
@@ -197,4 +198,3 @@ https://mltshp.com/p/1R9EG
 https://mltshp.com/p/1R9GO
 https://mltshp.com/p/1R9GS
 https://mltshp.com/p/1R9G2
-https://mltshp.com/p/1R9GL

--- a/links.log
+++ b/links.log
@@ -1,4 +1,3 @@
-https://mltshp.com/p/1R8OY
 https://mltshp.com/p/1R8Q7
 https://mltshp.com/p/1R8P8
 https://mltshp.com/p/1R8QB
@@ -198,3 +197,4 @@ https://mltshp.com/p/1R9EG
 https://mltshp.com/p/1R9GO
 https://mltshp.com/p/1R9GS
 https://mltshp.com/p/1R9G2
+https://mltshp.com/p/1R9GL


### PR DESCRIPTION
- Quietly ignore any popular posts without alt text
- Also ignore posts with alt text set to `CDN Media` or `image`